### PR TITLE
Update sync label for blockingProcess

### DIFF
--- a/fragments/labels/sync.sh
+++ b/fragments/labels/sync.sh
@@ -4,4 +4,5 @@ sync)
     downloadURL="https://www.sync.com/download/apple/Sync.dmg"
     appNewVersion="$(curl -fs "https://www.sync.com/blog/category/desktop/feed/" | xpath '(//channel/item/title)[1]' 2>/dev/null | sed -E 's/^.* ([0-9.]*) .*$/\1/g')"
     expectedTeamID="7QR39CMJ3W"
+    blockingProcesses=( "Sync" "sync-worker.exe" )
     ;;


### PR DESCRIPTION
This allows sync to be updated by ensuring all blocking processes are killed first